### PR TITLE
Remove font weight parameter

### DIFF
--- a/arcadia_pycolor/mplstyles/arcadia_basic.mplstyle
+++ b/arcadia_pycolor/mplstyles/arcadia_basic.mplstyle
@@ -92,7 +92,6 @@ patch.antialiased      : True    # render patches in antialiased (no jaggies)
 ### FONT
 font.family         : sans-serif
 font.size           : 12.0
-font.weight         : 300
 font.serif     : Suisse Intl Serif, DejaVu Serif, New Century Schoolbook, Century Schoolbook L, Utopia, ITC Bookman, Bookman, Nimbus Roman No9 L, Times New Roman, Times, Palatino, Charter, serif
 font.sans-serif: Suisse Intl, Arial, DejaVu Sans, Lucida Grande, Verdana, Geneva, Lucid, Helvetica, Avant Garde, sans-serif
 font.monospace : Suisee Intl Mono, Arial, Courier, DejaVu Sans Mono, Andale Mono, Nimbus Mono L, Courier New, Fixed, Terminal, monospace

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
         "colorspacious>=1.1.2",
         "ipython>=8.16.1",
     ],
-    version="0.3.1",
+    version="0.3.2",
     license="MIT",
     description="A Python package to distribute Arcadia's color and style guidelines for figures.",
     package_dir={"arcadia_pycolor": "arcadia_pycolor"},


### PR DESCRIPTION
The font weight parameter in the mpl stylesheet can throw errors if a font with the exact weight value is not found on the system. This removes that parameter.