### PR TITLE
Import fixes

### DIFF
--- a/arcadia_pycolor/__init__.py
+++ b/arcadia_pycolor/__init__.py
@@ -1,19 +1,22 @@
 from arcadia_pycolor import colors, cvd, gradients, mpl, palettes, plot, style_defaults
 
 from .colors import *
-from .gradient import *
-from .hexcode import *
-from .palette import *
+from .gradient import Gradient
+from .hexcode import HexCode
+from .palette import Palette
 
 __all__ = [
     "cvd",
+    "Gradient",
     "gradients",
+    "HexCode",
     "mpl",
+    "Palette",
     "palettes",
     "plot",
     "style_defaults",
 ]
 
-colors_all = [name for name in dir(colors) if not name.startswith("_")]
+colors_all = [name for name in dir(colors) if isinstance(getattr(colors, name), HexCode)]
 
 __all__.extend(colors_all)  # type: ignore

--- a/arcadia_pycolor/tests/test_utils.py
+++ b/arcadia_pycolor/tests/test_utils.py
@@ -1,6 +1,6 @@
 import pytest
 
-from arcadia_pycolor import distribute_values
+from arcadia_pycolor.utils import distribute_values
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This PR addresses #40 and also removes the star imports in the top-level `__init__` in favor of explicit imports (and adds them to `__all__`). 