### PR TITLE
Add __version__

### DIFF
--- a/arcadia_pycolor/__init__.py
+++ b/arcadia_pycolor/__init__.py
@@ -5,6 +5,8 @@ from .gradient import Gradient
 from .hexcode import HexCode
 from .palette import Palette
 
+__version__ = "0.5.2-dev"
+
 __all__ = [
     "cvd",
     "Gradient",


### PR DESCRIPTION
I just updated my arcadia-pycolor version but besides checking my lock file I had no good way to confirm I was importing the correct version.

It is standard to put a package's version in the top-level `__init__.py` under the variable `__version__`:

```python
>>> import importlib
>>> importlib.import_module("numpy").__version__
'1.26.4'
>>> importlib.import_module("pandas").__version__
'2.2.2'
>>> importlib.import_module("biotite").__version__
'0.40.0'
>>> importlib.import_module("dask").__version__
'2024.6.2'
>>> importlib.import_module("arcadia_pycolor").__version__
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: module 'arcadia_pycolor' has no attribute '__version__'
```

This PR adds `__version__`. Since we are now between 0.5.1 and 0.5.2, I've appended a pre-release identifier `-dev`. We could start doing `-dev.X`, `-rc.X`, `-alpha.X`, `-beta.X`, etc, but IMO this package doesn't require anything more complex than `-dev`. 