### PR TITLE
add size options to get_figure_dimensions docstring

### DIFF
--- a/arcadia_pycolor/mpl.py
+++ b/arcadia_pycolor/mpl.py
@@ -306,7 +306,12 @@ def style_plot(
 
 
 def get_figure_dimensions(size: str) -> tuple[float, ...]:
-    "Return the dimensions of a figure given a size, subtracting the spacing needed for margins."
+    """Return the dimensions of a figure given a size, subtracting the spacing needed for margins.
+
+    Args:
+        size (str) : the desired figure size,
+            either "full_wide", "full_square", "float_wide", "float_square", or "half_square"
+    """
 
     if size not in FIGURE_SIZES:
         raise ValueError(f"Size must be one of {list(FIGURE_SIZES.keys())}.")


### PR DESCRIPTION
<!--
Many thanks for contributing to Arcadia-Science/arcadia-pycolor!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).
-->

This is a small PR to include the figure size options in the docstring of `get_figure_dimensions` so I (and others!) wouldn't have to search elsewhere.

## PR checklist

- [x] Describe the changes you've made.
