### PR TITLE
Fix dev install command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ For detailed documentation about the package and links to example plots, see the
 We use poetry to manage dependencies and packaging. First, create a new conda environment and install poetry:
 
 ```bash
-conda create -n arcadia-pycolor -f envs/dev.yml
+conda env create -n arcadia-pycolor -f envs/dev.yml
 conda activate arcadia-pycolor
 ```
 


### PR DESCRIPTION
`env` needed in command to create a new environment. Otherwise results in
```
PackagesNotFoundError: The following packages are not available from current channels:

  - envs/dev.yml
```

<!--
Many thanks for contributing to Arcadia-Science/arcadia-pycolor!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).
-->

## PR checklist

- [x] Describe the changes you've made.
