### PR TITLE
Remove instances of types as strings

### DIFF
--- a/arcadia_pycolor/display.py
+++ b/arcadia_pycolor/display.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
-from typing import TYPE_CHECKING
 
-if TYPE_CHECKING:
-    from arcadia_pycolor.hexcode import HexCode
+from arcadia_pycolor.hexcode import HexCode
 
 
 def colorize(

--- a/arcadia_pycolor/display.py
+++ b/arcadia_pycolor/display.py
@@ -1,4 +1,5 @@
-from typing import TYPE_CHECKING, Optional
+from __future__ import annotations
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from arcadia_pycolor.hexcode import HexCode
@@ -6,8 +7,8 @@ if TYPE_CHECKING:
 
 def colorize(
     string: str,
-    fg_color: Optional["HexCode"] = None,
-    bg_color: Optional["HexCode"] = None,
+    fg_color: HexCode | None = None,
+    bg_color: HexCode | None = None,
 ):
     """
     Colorizes a string with the specified foreground and background colors.

--- a/arcadia_pycolor/display.py
+++ b/arcadia_pycolor/display.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
+from typing import TYPE_CHECKING
 
-from arcadia_pycolor.hexcode import HexCode
+if TYPE_CHECKING:
+    from arcadia_pycolor.hexcode import HexCode
 
 
 def colorize(

--- a/arcadia_pycolor/gradient.py
+++ b/arcadia_pycolor/gradient.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from dataclasses import dataclass
 from typing import Union
 
@@ -79,7 +80,7 @@ class Gradient:
     @classmethod
     def from_dict(
         cls, name: str, colors: dict[str, str], values: Union[list[float], None] = None
-    ) -> "Gradient":
+    ) -> Gradient:
         hex_codes = [HexCode(name, hex_code) for name, hex_code in colors.items()]
         return cls(name, hex_codes, values)
 
@@ -103,7 +104,7 @@ class Gradient:
 
         return "".join(swatches)
 
-    def reverse(self) -> "Gradient":
+    def reverse(self) -> Gradient:
         """Returns a new gradient with the colors and values in reverse order"""
         return Gradient(
             name=f"{self.name}_r",
@@ -169,7 +170,7 @@ class Gradient:
 
         return [HexCode(f"{value}", mcolors.to_hex(cmap(value))) for value in normalized_values]
 
-    def interpolate_lightness(self) -> "Gradient":
+    def interpolate_lightness(self) -> Gradient:
         """
         Interpolates the gradient to new values based on lightness.
         """
@@ -188,7 +189,7 @@ class Gradient:
             values=new_values,
         )
 
-    def __add__(self, other: "Gradient") -> "Gradient":
+    def __add__(self, other: Gradient) -> Gradient:
         """
         Return the sum of two gradients by concatenating their colors and values.
         """

--- a/arcadia_pycolor/gradient.py
+++ b/arcadia_pycolor/gradient.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 from dataclasses import dataclass
-from typing import Union
 
 import matplotlib.colors as mcolors
 
@@ -31,7 +30,7 @@ class Anchor:
 
 
 class Gradient:
-    def __init__(self, name: str, colors: list[HexCode], values: Union[list[float], None] = None):
+    def __init__(self, name: str, colors: list[HexCode], values: list[float] | None = None):
         """
         A Gradient is a sequence of anchors (paired colors and values)
         that can create interpolated color sequences.
@@ -79,7 +78,7 @@ class Gradient:
 
     @classmethod
     def from_dict(
-        cls, name: str, colors: dict[str, str], values: Union[list[float], None] = None
+        cls, name: str, colors: dict[str, str], values: list[float] | None = None
     ) -> Gradient:
         hex_codes = [HexCode(name, hex_code) for name, hex_code in colors.items()]
         return cls(name, hex_codes, values)
@@ -131,8 +130,8 @@ class Gradient:
     def map_values(
         self,
         values: NumericSequence,
-        min_value: Union[float, None] = None,
-        max_value: Union[float, None] = None,
+        min_value: float | None = None,
+        max_value: float | None = None,
     ) -> list[HexCode]:
         """Map a sequence of values to their corresponding colors from a gradient
 

--- a/arcadia_pycolor/hexcode.py
+++ b/arcadia_pycolor/hexcode.py
@@ -1,5 +1,6 @@
+from __future__ import annotations
 import re
-from typing import Any, Union, cast
+from typing import Any, cast
 
 import matplotlib.colors as mcolors
 from colorspacious import cspace_converter  # type: ignore
@@ -19,7 +20,7 @@ def _is_hex_code(hex_string: Any) -> bool:
 
 
 class HexCode(str):
-    def __new__(cls, name: str, hex_code: str) -> "HexCode":
+    def __new__(cls, name: str, hex_code: str) -> HexCode:
         """
         A HexCode object stores a color's name and HEX code.
 
@@ -69,7 +70,7 @@ class HexCode(str):
 
         return cam02ucs
 
-    def swatch(self, width: int = 2, min_name_width: Union[int, None] = None) -> str:
+    def swatch(self, width: int = 2, min_name_width: int | None = None) -> str:
         """
         Returns a color swatch with the specified width and color name.
 

--- a/arcadia_pycolor/palette.py
+++ b/arcadia_pycolor/palette.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import Union, overload
+from typing import overload
 
 import matplotlib.colors as mcolors
 
@@ -73,7 +73,7 @@ class Palette:
     @overload
     def __getitem__(self, index: slice) -> Palette: ...
 
-    def __getitem__(self, index: Union[int, slice]) -> Union[HexCode, Palette]:
+    def __getitem__(self, index: int | slice) -> HexCode | Palette:
         """Returns the color at the given index, or a new palette if a slice is provided.
 
         Args:

--- a/arcadia_pycolor/palette.py
+++ b/arcadia_pycolor/palette.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from typing import Union, overload
 
 import matplotlib.colors as mcolors
@@ -27,7 +28,7 @@ class Palette:
         self.colors = colors
 
     @classmethod
-    def from_dict(cls, name: str, colors: dict[str, str]) -> "Palette":
+    def from_dict(cls, name: str, colors: dict[str, str]) -> Palette:
         """
         Create a Palette from a dictionary of color names and hex codes.
 
@@ -45,7 +46,7 @@ class Palette:
         swatches = [colorize("  ", bg_color=color) for color in self.colors]
         return "".join(swatches)
 
-    def reverse(self) -> "Palette":
+    def reverse(self) -> Palette:
         """
         Returns a new palette with the colors in reverse order.
         """
@@ -70,9 +71,9 @@ class Palette:
     def __getitem__(self, index: int) -> HexCode: ...
 
     @overload
-    def __getitem__(self, index: slice) -> "Palette": ...
+    def __getitem__(self, index: slice) -> Palette: ...
 
-    def __getitem__(self, index: Union[int, slice]) -> Union[HexCode, "Palette"]:
+    def __getitem__(self, index: Union[int, slice]) -> Union[HexCode, Palette]:
         """Returns the color at the given index, or a new palette if a slice is provided.
 
         Args:
@@ -96,7 +97,7 @@ class Palette:
             + [color.swatch(min_name_width=longest_name_length) for color in self.colors]
         )
 
-    def __add__(self, other: "Palette") -> "Palette":
+    def __add__(self, other: Palette) -> Palette:
         """Returns a new palette that is the concatenation of this palette and another."""
         return Palette(
             name=f"{self.name}+{other.name}",

--- a/arcadia_pycolor/plot.py
+++ b/arcadia_pycolor/plot.py
@@ -12,7 +12,7 @@ from arcadia_pycolor.palettes import all_palettes
 
 
 def plot_gradient_lightness(
-    gradients: Union["Gradient", str, list["Gradient"], list[str]],
+    gradients: Union[Gradient, str, list[Gradient], list[str]],
     title: Union[str, None] = None,
     horizontal_spacing: float = 1.1,
     steps: int = 100,


### PR DESCRIPTION
Specifying types as strings is confusing. For example, `Literal["Foo"]` and `List["Foo"]` have *very* different meanings of `Foo`. This lack of clarity is absolved with `List[Foo]`. It's also better to have a consistent style, where we don't mix types as strings with types as objects.

Given this, I wanted to test out Claude Code so I gave it the prompt to replace all types-as-string references with delayed type evaluation (`from __future__ import annotations`).

I then went manually through and added some types where possible.

The future import also enables `X | Y` type annotations for 3.9 (even though its a 3.10 feature). Ruff sees the `from __future__ import annotations` import and smartly complains about `Union`, recommending `X | Y` instead. So I changed those too.

Here is the Claude Code log for the first pass of the work (which did miss some!)

```
▶▶ claude
╭──────────────────────────────────────────────────────╮
│ ✻ Welcome to Claude Code research preview!           │
│                                                      │
│   /help for help                                     │
│                                                      │
│   cwd: /Users/evan/Software/arcadia/arcadia-pycolor  │
╰──────────────────────────────────────────────────────╯

 Tips for getting started:

 1. Run /init to create a CLAUDE.md file with instructions for Claude.
 2. Run /terminal-setup to set up terminal integration
 3. Ask Claude questions about your codebase.
 4. Ask Claude to implement changes to your codebase.

> Please find all instances of types specified as strings and replace them with their proper types. Of course, this will need to be accompanied with from
  __future__ import annotations.

⏺ Task(Search for all files with type annotations as strings in the codebase. Look for patterns like:…)…
  ⎿  Done (11 tool uses · 27.9k tokens · 34.8s)

⏺ Let me update the files with proper type annotations.

⏺ Read(file_path: "arcadia_pycolor/palette.py")…
  ⎿  from typing import Union, overload
     import matplotlib.colors as mcolors
     ... (+108 lines)

⏺ Read(file_path: "arcadia_pycolor/gradient.py")…
  ⎿  from dataclasses import dataclass
     from typing import Union
     ... (+241 lines)

⏺ Read(file_path: "arcadia_pycolor/cvd.py")…
  ⎿  from typing import Any, Union, cast, overload
     import matplotlib as mpl
     ... (+155 lines)

⏺ Now I'll update the files to replace string type annotations with proper types, adding the from __future__ import annotations at the top of each file:

⏺ Update(file_path: arcadia_pycolor/palette.py)…
  ⎿ Updated arcadia_pycolor/palette.py with 2 additions
     1  from __future__ import annotations
     2
     3  from typing import Union, overload
     4
     5  import matplotlib.colors as mcolors

⏺ Update(file_path: arcadia_pycolor/palette.py)…
  ⎿ Updated arcadia_pycolor/palette.py with 1 addition and 1 removal
     29          self.colors = colors
     30
     31      @classmethod
     32      def from_dict(cls, name: str, colors: dict[str, str]) -> "Palette":
     32      def from_dict(cls, name: str, colors: dict[str, str]) -> Palette:
     33          """
     34          Create a Palette from a dictionary of color names and hex codes.
     35

⏺ Update(file_path: arcadia_pycolor/palette.py)…
  ⎿ Updated arcadia_pycolor/palette.py with 1 addition and 1 removal
     47          swatches = [colorize("  ", bg_color=color) for color in self.colors]
     48          return "".join(swatches)
     49
     50      def reverse(self) -> "Palette":
     50      def reverse(self) -> Palette:
     51          """
     52          Returns a new palette with the colors in reverse order.
     53          """

⏺ Update(file_path: arcadia_pycolor/palette.py)…
  ⎿ Updated arcadia_pycolor/palette.py with 1 addition and 1 removal
     72      def __getitem__(self, index: int) -> HexCode: ...
     73
     74      @overload
     75      def __getitem__(self, index: slice) -> "Palette": ...
     75      def __getitem__(self, index: slice) -> Palette: ...
     76
     77      def __getitem__(self, index: Union[int, slice]) -> Union[HexCode, "Palette"]:
     78          """Returns the color at the given index, or a new palette if a slice is provided.

⏺ Update(file_path: arcadia_pycolor/palette.py)…
  ⎿ Updated arcadia_pycolor/palette.py with 1 addition and 1 removal
     74      @overload
     75      def __getitem__(self, index: slice) -> Palette: ...
     76
     77      def __getitem__(self, index: Union[int, slice]) -> Union[HexCode, "Palette"]:
     77      def __getitem__(self, index: Union[int, slice]) -> Union[HexCode, Palette]:
     78          """Returns the color at the given index, or a new palette if a slice is provided.
     79
     80          Args:

⏺ Update(file_path: arcadia_pycolor/palette.py)…
  ⎿ Updated arcadia_pycolor/palette.py with 1 addition and 1 removal
      98              + [color.swatch(min_name_width=longest_name_length) for color in self.colors]
      99          )
     100
     101      def __add__(self, other: "Palette") -> "Palette":
     101      def __add__(self, other: Palette) -> Palette:
     102          """Returns a new palette that is the concatenation of this palette and another."""
     103          return Palette(
     104              name=f"{self.name}+{other.name}",

⏺ Update(file_path: arcadia_pycolor/gradient.py)…
  ⎿ Updated arcadia_pycolor/gradient.py with 2 additions
     1  from __future__ import annotations
     2
     3  from dataclasses import dataclass
     4  from typing import Union
     5

⏺ Update(file_path: arcadia_pycolor/gradient.py)…
  ⎿ Updated arcadia_pycolor/gradient.py with 1 addition and 1 removal
     81      @classmethod
     82      def from_dict(
     83          cls, name: str, colors: dict[str, str], values: Union[list[float], None] = None
     84      ) -> "Gradient":
     84      ) -> Gradient:
     85          hex_codes = [HexCode(name, hex_code) for name, hex_code in colors.items()]
     86          return cls(name, hex_codes, values)
     87

⏺ Update(file_path: arcadia_pycolor/gradient.py)…
  ⎿ Updated arcadia_pycolor/gradient.py with 1 addition and 1 removal
     105
     106          return "".join(swatches)
     107
     108      def reverse(self) -> "Gradient":
     108      def reverse(self) -> Gradient:
     109          """Returns a new gradient with the colors and values in reverse order"""
     110          return Gradient(
     111              name=f"{self.name}_r",

⏺ Update(file_path: arcadia_pycolor/gradient.py)…
  ⎿ Updated arcadia_pycolor/gradient.py with 1 addition and 1 removal
     171
     172          return [HexCode(f"{value}", mcolors.to_hex(cmap(value))) for value in normalized_values]
     173
     174      def interpolate_lightness(self) -> "Gradient":
     174      def interpolate_lightness(self) -> Gradient:
     175          """
     176          Interpolates the gradient to new values based on lightness.
     177          """

⏺ Update(file_path: arcadia_pycolor/gradient.py)…
  ⎿ Updated arcadia_pycolor/gradient.py with 1 addition and 1 removal
     190              values=new_values,
     191          )
     192
     193      def __add__(self, other: "Gradient") -> "Gradient":
     193      def __add__(self, other: Gradient) -> Gradient:
     194          """
     195          Return the sum of two gradients by concatenating their colors and values.
     196          """

⏺ Update(file_path: arcadia_pycolor/cvd.py)…
  ⎿ Updated arcadia_pycolor/cvd.py with 2 additions
     1  from __future__ import annotations
     2
     3  from typing import Any, Union, cast, overload
     4
     5  import matplotlib as mpl

⏺ Let me run a final check to make sure all string type annotations have been replaced:

⏺ Task(Search the codebase again for any remaining type annotations that are still using strings after our updates. Check the files we just updated:…)…
  ⎿  Done (14 tool uses · 9.6k tokens · 36.3s)

⏺ All string type annotations have been replaced with proper types in the affected files:

  1. Added from __future__ import annotations to the top of each file
  2. Updated all return types marked with strings like -> "Palette" to use the actual class names
  3. Updated parameter types that used string annotations to use proper class references

  The changes were made to:
  - palette.py
  - gradient.py
  - cvd.py

  These updates will help with static type checking and make the code more maintainable.
```

And here's the Claude Code job for replacing `Optional` and `Union` with `|`:

```
▶▶ claude
╭──────────────────────────────────────────────────────╮
│ ✻ Welcome to Claude Code research preview!           │
│                                                      │
│   /help for help                                     │
│                                                      │
│   cwd: /Users/evan/Software/arcadia/arcadia-pycolor  │
╰──────────────────────────────────────────────────────╯

> Replace Optional and Union with | in all files with from __future__ import annotations is present.

⏺ Search(pattern: "from __future__ import annotations", include: "*.py")…
  ⎿  Found 4 files

⏺ Search(pattern: "Union|Optional", path: "arcadia_pycolor", include: "*.py")…
  ⎿  Found 8 files

⏺ Read(file_path: "arcadia_pycolor/display.py")…
  ⎿  from __future__ import annotations
     from typing import TYPE_CHECKING, Optional
     ... (+33 lines)

⏺ Read(file_path: "arcadia_pycolor/hexcode.py")…
  ⎿  from __future__ import annotations
     import re
     from typing import Any, Union, cast
     ... (+104 lines)

⏺ Read(file_path: "arcadia_pycolor/gradient.py")…
  ⎿  from __future__ import annotations
     from dataclasses import dataclass
     from typing import Union
     ... (+242 lines)

⏺ Read(file_path: "arcadia_pycolor/palette.py")…
  ⎿  from __future__ import annotations
     from typing import Union, overload
     ... (+109 lines)

⏺ Now I'll make the necessary edits to replace Optional and Union with | in the files that use from __future__ import annotations.

⏺ Update(file_path: arcadia_pycolor/display.py)…
  ⎿ Updated arcadia_pycolor/display.py with 3 additions and 3 removals
     1  from __future__ import annotations
     2  from typing import TYPE_CHECKING, Optional
     2  from typing import TYPE_CHECKING
     3
     4  if TYPE_CHECKING:
     5      from arcadia_pycolor.hexcode import HexCode
     ...
      7
      8  def colorize(
      9      string: str,
     10      fg_color: Optional[HexCode] = None,
     11      bg_color: Optional[HexCode] = None,
     10      fg_color: HexCode | None = None,
     11      bg_color: HexCode | None = None,
     12  ):
     13      """
     14      Colorizes a string with the specified foreground and background colors.

⏺ Update(file_path: arcadia_pycolor/hexcode.py)…
  ⎿ Updated arcadia_pycolor/hexcode.py with 1 addition and 1 removal
     1  from __future__ import annotations
     2  import re
     3  from typing import Any, Union, cast
     3  from typing import Any, cast
     4
     5  import matplotlib.colors as mcolors
     6  from colorspacious import cspace_converter  # type: ignore

⏺ Update(file_path: arcadia_pycolor/hexcode.py)…
  ⎿ Updated arcadia_pycolor/hexcode.py with 1 addition and 1 removal
     70
     71          return cam02ucs
     72
     73      def swatch(self, width: int = 2, min_name_width: Union[int, None] = None) -> str:
     73      def swatch(self, width: int = 2, min_name_width: int | None = None) -> str:
     74          """
     75          Returns a color swatch with the specified width and color name.
     76

⏺ Update(file_path: arcadia_pycolor/gradient.py)…
  ⎿ Updated arcadia_pycolor/gradient.py with 1 removal
     1  from __future__ import annotations
     2  from dataclasses import dataclass
     3  from typing import Union
     3
     4  import matplotlib.colors as mcolors
     5

⏺ Update(file_path: arcadia_pycolor/gradient.py)…
  ⎿ Updated arcadia_pycolor/gradient.py with 1 addition and 1 removal
     30
     31
     32  class Gradient:
     33      def __init__(self, name: str, colors: list[HexCode], values: Union[list[float], None] = None):
     33      def __init__(self, name: str, colors: list[HexCode], values: list[float] | None = None):
     34          """
     35          A Gradient is a sequence of anchors (paired colors and values)
     36          that can create interpolated color sequences.

⏺ Update(file_path: arcadia_pycolor/gradient.py)…
  ⎿ Updated arcadia_pycolor/gradient.py with 1 addition and 1 removal
     78
     79      @classmethod
     80      def from_dict(
     81          cls, name: str, colors: dict[str, str], values: Union[list[float], None] = None
     81          cls, name: str, colors: dict[str, str], values: list[float] | None = None
     82      ) -> Gradient:
     83          hex_codes = [HexCode(name, hex_code) for name, hex_code in colors.items()]
     84          return cls(name, hex_codes, values)

⏺ Update(file_path: arcadia_pycolor/gradient.py)…
  ⎿ Updated arcadia_pycolor/gradient.py with 2 additions and 2 removals
     130      def map_values(
     131          self,
     132          values: NumericSequence,
     133          min_value: Union[float, None] = None,
     134          max_value: Union[float, None] = None,
     133          min_value: float | None = None,
     134          max_value: float | None = None,
     135      ) -> list[HexCode]:
     136          """Map a sequence of values to their corresponding colors from a gradient
     137

⏺ Update(file_path: arcadia_pycolor/palette.py)…
  ⎿ Updated arcadia_pycolor/palette.py with 1 addition and 1 removal
     1  from __future__ import annotations
     2  from typing import Union, overload
     2  from typing import overload
     3
     4  import matplotlib.colors as mcolors
     5

⏺ Update(file_path: arcadia_pycolor/palette.py)…
  ⎿ Updated arcadia_pycolor/palette.py with 1 addition and 1 removal
     73      @overload
     74      def __getitem__(self, index: slice) -> Palette: ...
     75
     76      def __getitem__(self, index: Union[int, slice]) -> Union[HexCode, Palette]:
     76      def __getitem__(self, index: int | slice) -> HexCode | Palette:
     77          """Returns the color at the given index, or a new palette if a slice is provided.
     78
     79          Args:

⏺ I've replaced all instances of Optional and Union with the | syntax in the files that use from __future__ import annotations. Here's a summary of the changes:

  1. In display.py:
    - Changed Optional[HexCode] to HexCode | None
  2. In hexcode.py:
    - Removed Union from imports
    - Changed Union[int, None] to int | None
  3. In gradient.py:
    - Removed Union from imports
    - Changed Union[list[float], None] to list[float] | None
    - Changed Union[float, None] to float | None
  4. In palette.py:
    - Removed Union from imports
    - Changed Union[int, slice] to int | slice
    - Changed Union[HexCode, Palette] to HexCode | Palette
```