### PR TITLE
Add notebook execution to CI

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -35,15 +35,14 @@ jobs:
           virtualenvs-in-project: true
 
       - name: Cache Poetry dependencies
-        id: cache-poetry-deps
+        id: cache-deps
         uses: actions/cache@v2
         with:
           path: .venv
           key: pydeps-${{ hashFiles('**/poetry.lock') }}
 
-      - run: poetry install --no-interaction --no-root
-        if: steps.cache-poetry-deps.outputs.cache-hit != 'true'
-
+      - run: poetry install --no-interaction --no-root --with=dev
+        if: steps.cache-deps.outputs.cache-hit != 'true'
       - name: Run Ruff
         run: poetry run ruff check --output-format=github .
 
@@ -52,3 +51,14 @@ jobs:
 
       - name: Run tests
         run: poetry run pytest
+
+      # This is necessary to prevent the following error when installing the package in CI:
+      # "RuntimeError: This is a shallow repository, so Dunamai may not produce the correct version."
+      - name: Fetch full Git history
+        run: git fetch --unshallow --tags
+
+      - name: Install arcadia-pycolor
+        run: poetry run pip install .
+
+      - name: Execute notebooks
+        run: make execute-all-notebooks

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -27,7 +27,7 @@ jobs:
           python-version: "3.9"
 
       - name: Cache Poetry install
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.local
           key: poetry-1.8.3-0
@@ -41,7 +41,7 @@ jobs:
 
       - name: Cache Poetry dependencies
         id: cache-deps
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: .venv
           key: pydeps-${{ hashFiles('**/poetry.lock') }}

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -15,6 +15,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        # Fetching the full git history is necessary because poetry's dynamic versioning extension
+        # requires it, and this extension is run even when the package is pip-installed locally
+        # (as we do below).
+        with:
+          fetch-depth: 0
 
       - name: Install Python
         uses: actions/setup-python@v4
@@ -51,11 +56,6 @@ jobs:
 
       - name: Run tests
         run: poetry run pytest
-
-      # This is necessary to prevent the following error when installing the package in CI:
-      # "RuntimeError: This is a shallow repository, so Dunamai may not produce the correct version."
-      - name: Fetch full Git history
-        run: git fetch --unshallow --tags
 
       - name: Install arcadia-pycolor
         run: poetry run pip install .

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ endif
 execute-all-notebooks:
 	@for file in $(JUPYTER_NOTEBOOKS); do \
 		echo "Executing notebook $$file"; \
-		jupyter execute --inplace $$file; \
+		poetry run jupyter execute --inplace $$file; \
 	done
 
 .PHONY: lint

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,8 @@ endif
 
 .PHONY: execute-all-notebooks
 execute-all-notebooks:
-	@for file in $(JUPYTER_NOTEBOOKS); do \
+	@if [ -n "$$CI" ]; then set -e; fi; \
+	for file in $(JUPYTER_NOTEBOOKS); do \
 		echo "Executing notebook $$file"; \
 		poetry run jupyter execute --inplace $$file; \
 	done

--- a/docs/color_usage.ipynb
+++ b/docs/color_usage.ipynb
@@ -30,7 +30,9 @@
     "import numpy as np\n",
     "import seaborn as sns\n",
     "\n",
-    "import arcadia_pycolor as apc"
+    "import arcadia_pycolor as apc\n",
+    "\n",
+    "print(meow)"
    ]
   },
   {

--- a/docs/color_usage.ipynb
+++ b/docs/color_usage.ipynb
@@ -30,9 +30,7 @@
     "import numpy as np\n",
     "import seaborn as sns\n",
     "\n",
-    "import arcadia_pycolor as apc\n",
-    "\n",
-    "print(meow)"
+    "import arcadia_pycolor as apc"
    ]
   },
   {

--- a/docs/color_usage.ipynb
+++ b/docs/color_usage.ipynb
@@ -30,10 +30,7 @@
     "import numpy as np\n",
     "import seaborn as sns\n",
     "\n",
-    "import arcadia_pycolor as apc\n",
-    "\n",
-    "my_list = []\n",
-    "my_list[3]"
+    "import arcadia_pycolor as apc"
    ]
   },
   {

--- a/docs/color_usage.ipynb
+++ b/docs/color_usage.ipynb
@@ -32,7 +32,8 @@
     "\n",
     "import arcadia_pycolor as apc\n",
     "\n",
-    "print(hello_world)"
+    "my_list = []\n",
+    "my_list[3]"
    ]
   },
   {

--- a/docs/color_usage.ipynb
+++ b/docs/color_usage.ipynb
@@ -30,7 +30,9 @@
     "import numpy as np\n",
     "import seaborn as sns\n",
     "\n",
-    "import arcadia_pycolor as apc"
+    "import arcadia_pycolor as apc\n",
+    "\n",
+    "print(hello_world)"
    ]
   },
   {


### PR DESCRIPTION
## Summary

Execute notebooks in CI workflow. Completes #38.

## Changes

- Prefix `jupyter` command with `poetry run` in makefile.
- In CI environment, exit early if there are any notebook errors.
- Fetch entire commit history and tags in order to install the package in CI (see [here](https://github.com/mtkennerly/poetry-dynamic-versioning/discussions/132)).
- Run `make execute-all-notebooks` in CI.

## Tests

- Verified that the `make` command exits early on notebook execution error in CI environment. See [this job](https://github.com/Arcadia-Science/arcadia-pycolor/actions/runs/13638825344/job/38123805950).
- Re-ran the `execute-all-notebooks` command locally to verify that there were no regressions.