### PR TITLE
Replace shorthand CSS font styles in SVG exports for Adobe Illustrator

### DIFF
--- a/arcadia_pycolor/mpl.py
+++ b/arcadia_pycolor/mpl.py
@@ -101,11 +101,11 @@ def _find_macos_arcadia_fonts() -> list[str]:
 def _fix_svg_fonts_for_illustrator(filename: str) -> None:
     """Replaces shorthand font styles in SVG exports with individual CSS font properties.
 
-    This is needed because Adobe Illustrator does not respect font weights in shorthand font styles
-    like "font: 500 15px SuisseIntl, sans-serif;". The axis titles and legend title had some font
-    weight applied, and because of this, they were not being rendered in Illustrator.
+    This is needed because Adobe Illustrator cannot parse font weights in shorthand font styles
+    like "font: 500 15px SuisseIntl, sans-serif;". The axis titles and legend title have font
+    weights applied, and because of this, font styles are not being rendered in Illustrator.
 
-    As a workaround, we explicitly set each CSS font property:
+    As a workaround, each CSS font property is explicitly set:
 
     ```html
     <text style="font-family: SuisseIntl, sans-serif; font-size: 15px; font-weight: 500;">

--- a/arcadia_pycolor/mpl.py
+++ b/arcadia_pycolor/mpl.py
@@ -99,17 +99,22 @@ def _find_macos_arcadia_fonts() -> list[str]:
 
 
 def _fix_svg_fonts_for_illustrator(filename: str) -> None:
-    """Replaces shorthand font styles in SVG exports with individual CSS font properties.
+    """Fixes CSS font styles in SVG exports for Adobe Illustrator.
 
-    This is needed because Adobe Illustrator cannot parse font weights in shorthand font styles
-    like "font: 500 15px SuisseIntl, sans-serif;". The axis titles and legend title have font
-    weights applied, and because of this, font styles are not being rendered in Illustrator.
+    Adobe Illustrator cannot parse font weights in shorthand font styles like
+    "font: 500 15px SuisseIntl, sans-serif;". The axis titles and legend title have font
+    weights applied, and because of this, their fonts are not being rendered correctly
+    in Illustrator.
 
     As a workaround, each CSS font property is explicitly set:
 
     ```html
     <text style="font-family: SuisseIntl, sans-serif; font-size: 15px; font-weight: 500;">
     ```
+
+    Additionally, the font family is not being applied correctly in Illustrator
+    when it is encoded as "&quot;Suisse Int&apos;l&quot;". To fix this, we replace
+    all instances of this encoding with "SuisseIntl".
 
     For more context, see https://github.com/Arcadia-Science/arcadia-pycolor/issues/68.
 
@@ -129,6 +134,7 @@ def _fix_svg_fonts_for_illustrator(filename: str) -> None:
         return f"font-family: {font_family},{fallback}; font-size: {size}px; font-weight: {weight};"
 
     new_content = re.sub(pattern, replace_font_style, content)
+    new_content = new_content.replace("&quot;Suisse Int&apos;l&quot;", "SuisseIntl")
 
     with open(filename, "w") as f:
         f.write(new_content)

--- a/arcadia_pycolor/mpl.py
+++ b/arcadia_pycolor/mpl.py
@@ -172,11 +172,10 @@ def save_figure(
             print(f"Invalid filetype '{ftype}'. Skipping.")
             continue
 
-        filename = f"{filename}.{ftype}"
-        plt.savefig(fname=filename, **kwargs)  # type: ignore
+        plt.savefig(fname=f"{filename}.{ftype}", **kwargs)  # type: ignore
 
         if ftype == "svg":
-            _fix_svg_fonts_for_illustrator(filename)
+            _fix_svg_fonts_for_illustrator(f"{filename}.{ftype}")
 
 
 def set_yticklabel_font(


### PR DESCRIPTION
## Summary

Replace shorthand CSS font styles (e.g. `500 15px SuisseIntl`) with individual CSS font properties (e.g. `font-family: SuisseIntl; font-size: 15px; font-weight: 500;`) to allow them to be rendered in Adobe Illustrator.

Fixes #68 for SVG exports.

## PR checklist

- [x] Tag the issue(s) or milestones this PR fixes (e.g. `Fixes #123, Resolves #456`).
- [x] Describe the changes you've made.
- [x] Describe any tests you have conducted to confirm that your changes behave as expected.
- [x] If you've added new software dependencies, make sure that those dependencies are included in the appropriate `conda` environments.
- [x] If you've added new functionality, make sure that the documentation is updated accordingly.
- [x] If you encountered bugs or features that you won't address, but should be addressed eventually, create new issues for them.
