### PR TITLE
Apply (or revert) fonts in Plotly HTML exports

### DIFF
--- a/arcadia_pycolor/plotly_utils.py
+++ b/arcadia_pycolor/plotly_utils.py
@@ -3,6 +3,7 @@ from typing import Any, Literal, Union, get_args
 
 import plotly.graph_objects as go
 import plotly.io as pio
+from bs4 import BeautifulSoup
 
 from arcadia_pycolor.style_defaults import (
     ARCADIA_PLOTLY_TEMPLATE_LAYOUT,
@@ -10,9 +11,9 @@ from arcadia_pycolor.style_defaults import (
     FIGURE_SIZES_IN_PIXELS,
     MONOSPACE_FONT_PLOTLY,
     MONOSPACE_FONT_SIZE,
+    PLOTLY_HTML_EXPORT_CSS,
     FigureSize,
 )
-from arcadia_pycolor.utils import add_fonts_to_plotly_html_export
 
 # Reference: https://plotly.com/python/3d-charts/.
 PLOTLY_3D_TRACE_TYPES = (
@@ -44,6 +45,11 @@ def _is_3d_plot(fig: go.Figure, row: Union[int, None] = None, col: Union[int, No
     return isinstance(fig.data[0], PLOTLY_3D_TRACE_TYPES)
 
 
+def _is_plot_with_3d_traces(fig: go.Figure) -> bool:
+    """Returns True if the figure data contains any 3D traces."""
+    return any(isinstance(trace, PLOTLY_3D_TRACE_TYPES) for trace in fig.data)
+
+
 def _is_plot_with_3d_traces_only(fig: go.Figure) -> bool:
     """Returns True if the figure data only contains 3D traces."""
     return all(isinstance(trace, PLOTLY_3D_TRACE_TYPES) for trace in fig.data)
@@ -57,6 +63,59 @@ def _is_plot_with_colorbar(fig: go.Figure) -> bool:
 def _is_plot_with_legend(fig: go.Figure) -> bool:
     """Returns True if the figure layout contains a non-empty legend."""
     return len(fig.layout.legend.to_plotly_json()) > 0  # type: ignore
+
+
+def _revert_to_default_fonts(fig: go.Figure) -> None:
+    """Reverts the fonts in a Plotly figure to the default Plotly fonts."""
+    template_without_fonts = go.Layout(**ARCADIA_PLOTLY_TEMPLATE_LAYOUT.to_plotly_json())
+
+    template_without_fonts.update(
+        font_family=None,
+        title_font_family=None,
+        legend_title_font_family=None,
+        legend_font_family=None,
+        hoverlabel_font_family=None,
+        coloraxis_colorbar_tickfont_family=None,
+        coloraxis_colorbar_title_font_family=None,
+        scene_xaxis_title_font_family=None,
+        scene_yaxis_title_font_family=None,
+        scene_zaxis_title_font_family=None,
+    )
+
+    fig.update_scenes(
+        xaxis_title_font_family=None,
+        yaxis_title_font_family=None,
+        zaxis_title_font_family=None,
+        xaxis_tickfont_family=None,
+        yaxis_tickfont_family=None,
+        zaxis_tickfont_family=None,
+    )
+
+    fig.update_layout(template=dict(layout=template_without_fonts))
+
+
+def _add_fonts_to_plotly_html_export(filepath: str) -> None:
+    """Adds a style tag with fonts loaded from arcadiascience.com to an HTML file's head section.
+
+    This is necessary for Plotly HTML exports to use the Suisse fonts.
+
+    Args:
+        filepath (str): Path to the HTML file to modify.
+    """
+    with open(filepath) as f:
+        content = f.read()
+
+    soup = BeautifulSoup(content, "html.parser")
+
+    style_tag = soup.new_tag("style")
+    style_tag.string = PLOTLY_HTML_EXPORT_CSS
+
+    if soup.head is None:
+        raise ValueError("Could not find <head> tag in HTML file.")
+    soup.head.append(style_tag)
+
+    with open(filepath, "w") as f:
+        f.write(str(soup))
 
 
 def save_figure(
@@ -122,16 +181,25 @@ def save_figure(
 
 
 def export_to_html(fig: go.Figure, filepath: str) -> None:
-    """Exports the current figure to an HTML file, with fonts loaded from arcadiascience.com.
+    """
+    Exports the current figure to an HTML file and adds fonts loaded from arcadiascience.com,
+    allowing the figure to be embedded on webpages without requiring fonts to be installed.
 
-    Allows the figure to be embedded on webpages without requiring the user to have fonts installed.
+    If the figure contains 3D traces, all fonts are reverted to default Plotly fonts.
+    This is because HTML exports of 3D plots do not apply remotely loaded fonts correctly.
+    See this issue for more details: https://github.com/plotly/plotly.js/issues/7413.
 
     Args:
         fig (go.Figure): The figure to export.
         filepath (str): The path to save the figure to.
     """
-    fig.write_html(filepath)
-    add_fonts_to_plotly_html_export(filepath)
+
+    if _is_plot_with_3d_traces(fig):
+        _revert_to_default_fonts(fig)
+        fig.write_html(filepath)
+    else:
+        fig.write_html(filepath)
+        _add_fonts_to_plotly_html_export(filepath)
 
 
 def set_yticklabel_font(

--- a/arcadia_pycolor/plotly_utils.py
+++ b/arcadia_pycolor/plotly_utils.py
@@ -75,8 +75,8 @@ def _revert_to_default_fonts(fig: go.Figure) -> None:
         legend_title_font_family=None,
         legend_font_family=None,
         hoverlabel_font_family=None,
-        coloraxis_colorbar_tickfont_family=None,
         coloraxis_colorbar_title_font_family=None,
+        coloraxis_colorbar_tickfont_family="monospace",
         xaxis_title_font_family=None,
         yaxis_title_font_family=None,
         scene_xaxis_title_font_family=None,
@@ -84,15 +84,30 @@ def _revert_to_default_fonts(fig: go.Figure) -> None:
         scene_zaxis_title_font_family=None,
     )
 
-    fig.update_layout(xaxis_tickfont_family=None, yaxis_tickfont_family=None)
+    is_monospaced_xaxis = fig.layout.xaxis.tickfont.family == MONOSPACE_FONT_PLOTLY  # type: ignore
+    is_monospaced_yaxis = fig.layout.yaxis.tickfont.family == MONOSPACE_FONT_PLOTLY  # type: ignore
+
+    fig.update_layout(
+        xaxis_tickfont_family="monospace" if is_monospaced_xaxis else None,
+        yaxis_tickfont_family="monospace" if is_monospaced_yaxis else None,
+        xaxis_tickfont_size=13.5 if is_monospaced_xaxis else None,
+        yaxis_tickfont_size=13.5 if is_monospaced_yaxis else None,
+    )
+
+    is_monospaced_xaxis = fig.layout.scene.xaxis.tickfont.family == MONOSPACE_FONT_PLOTLY  # type: ignore
+    is_monospaced_yaxis = fig.layout.scene.yaxis.tickfont.family == MONOSPACE_FONT_PLOTLY  # type: ignore
+    is_monospaced_zaxis = fig.layout.scene.zaxis.tickfont.family == MONOSPACE_FONT_PLOTLY  # type: ignore
 
     fig.update_scenes(
         xaxis_title_font_family=None,
         yaxis_title_font_family=None,
         zaxis_title_font_family=None,
-        xaxis_tickfont_family=None,
-        yaxis_tickfont_family=None,
-        zaxis_tickfont_family=None,
+        xaxis_tickfont_family="monospace" if is_monospaced_xaxis else None,
+        yaxis_tickfont_family="monospace" if is_monospaced_yaxis else None,
+        zaxis_tickfont_family="monospace" if is_monospaced_zaxis else None,
+        xaxis_tickfont_size=13.5 if is_monospaced_xaxis else None,
+        yaxis_tickfont_size=13.5 if is_monospaced_yaxis else None,
+        zaxis_tickfont_size=13.5 if is_monospaced_zaxis else None,
     )
 
     fig.update_layout(template=dict(layout=template_without_fonts))

--- a/arcadia_pycolor/plotly_utils.py
+++ b/arcadia_pycolor/plotly_utils.py
@@ -77,10 +77,14 @@ def _revert_to_default_fonts(fig: go.Figure) -> None:
         hoverlabel_font_family=None,
         coloraxis_colorbar_tickfont_family=None,
         coloraxis_colorbar_title_font_family=None,
+        xaxis_title_font_family=None,
+        yaxis_title_font_family=None,
         scene_xaxis_title_font_family=None,
         scene_yaxis_title_font_family=None,
         scene_zaxis_title_font_family=None,
     )
+
+    fig.update_layout(xaxis_tickfont_family=None, yaxis_tickfont_family=None)
 
     fig.update_scenes(
         xaxis_title_font_family=None,
@@ -97,7 +101,7 @@ def _revert_to_default_fonts(fig: go.Figure) -> None:
 def _add_fonts_to_plotly_html_export(filepath: str) -> None:
     """Adds a style tag with fonts loaded from arcadiascience.com to an HTML file's head section.
 
-    This is necessary for Plotly HTML exports to use the Suisse fonts.
+    This is necessary for embeds of Plotly HTML exports to use the Suisse fonts.
 
     Args:
         filepath (str): Path to the HTML file to modify.

--- a/arcadia_pycolor/plotly_utils.py
+++ b/arcadia_pycolor/plotly_utils.py
@@ -12,6 +12,7 @@ from arcadia_pycolor.style_defaults import (
     MONOSPACE_FONT_SIZE,
     FigureSize,
 )
+from arcadia_pycolor.utils import add_fonts_to_plotly_html_export
 
 # Reference: https://plotly.com/python/3d-charts/.
 PLOTLY_3D_TRACE_TYPES = (
@@ -118,6 +119,19 @@ def save_figure(
             print(f"Invalid filetype '{ftype}'. Skipping.")
             continue
         fig_export.write_image(f"{filename}.{ftype}", **write_image_kwargs)
+
+
+def export_to_html(fig: go.Figure, filepath: str) -> None:
+    """Exports the current figure to an HTML file, with fonts loaded from arcadiascience.com.
+
+    Allows the figure to be embedded on webpages without requiring the user to have fonts installed.
+
+    Args:
+        fig (go.Figure): The figure to export.
+        filepath (str): The path to save the figure to.
+    """
+    fig.write_html(filepath)
+    add_fonts_to_plotly_html_export(filepath)
 
 
 def set_yticklabel_font(

--- a/arcadia_pycolor/style_defaults.py
+++ b/arcadia_pycolor/style_defaults.py
@@ -1,3 +1,4 @@
+from textwrap import dedent
 from typing import Literal
 
 import matplotlib.pyplot as plt
@@ -276,4 +277,40 @@ ARCADIA_PLOTLY_TEMPLATE_LAYOUT = go.Layout(
         zerolinecolor="rgba(0,0,0,0)",
         zerolinewidth=0,
     ),
+)
+
+PLOTLY_HTML_EXPORT_CSS = dedent(
+    """
+    @font-face {
+      font-family: "SuisseIntl";
+      src: url("https://www.arcadiascience.com/fonts/SuisseIntl-Regular.woff2")
+        format("woff2");
+      font-weight: normal;
+      font-style: normal;
+    }
+
+    @font-face {
+      font-family: "SuisseIntl-Medium";
+      src: url("https://www.arcadiascience.com/fonts/SuisseIntl-Medium.woff2")
+        format("woff2");
+      font-weight: normal;
+      font-style: normal;
+    }
+
+    @font-face {
+      font-family: "SuisseIntl-SemiBold";
+      src: url("https://www.arcadiascience.com/fonts/SuisseIntl-SemiBold.woff2")
+        format("woff2");
+      font-weight: normal;
+      font-style: normal;
+    }
+
+    @font-face {
+      font-family: "SuisseIntlMono";
+      src: url("https://www.arcadiascience.com/fonts/SuisseIntlMono.woff2")
+        format("woff2");
+      font-weight: normal;
+      font-style: normal;
+    }
+    """
 )

--- a/arcadia_pycolor/utils.py
+++ b/arcadia_pycolor/utils.py
@@ -1,46 +1,8 @@
-from textwrap import dedent
 from typing import Sequence, Union
 
 import numpy as np
-from bs4 import BeautifulSoup
 
 NumericSequence = Union[Sequence[int], Sequence[float]]
-
-PLOTLY_HTML_EXPORT_CSS = dedent(
-    """
-    @font-face {
-      font-family: "SuisseIntl";
-      src: url("https://www.arcadiascience.com/fonts/SuisseIntl-Regular.woff2")
-        format("woff2");
-      font-weight: normal;
-      font-style: normal;
-    }
-
-    @font-face {
-      font-family: "SuisseIntl-Medium";
-      src: url("https://www.arcadiascience.com/fonts/SuisseIntl-Medium.woff2")
-        format("woff2");
-      font-weight: normal;
-      font-style: normal;
-    }
-
-    @font-face {
-      font-family: "SuisseIntl-SemiBold";
-      src: url("https://www.arcadiascience.com/fonts/SuisseIntl-SemiBold.woff2")
-        format("woff2");
-      font-weight: normal;
-      font-style: normal;
-    }
-
-    @font-face {
-      font-family: "SuisseIntlMono";
-      src: url("https://www.arcadiascience.com/fonts/SuisseIntlMono.woff2")
-        format("woff2");
-      font-weight: normal;
-      font-style: normal;
-    }
-    """
-)
 
 
 def distribute_values(num_points: int, min_val: float = 0.0, max_val: float = 1.0) -> list[float]:
@@ -111,27 +73,3 @@ def rescale_and_concatenate_values(list1: list[float], list2: list[float]) -> li
     rescaled_list1 = [0.5 * x for x in list1]
     rescaled_list2 = [0.5 * x + 0.5 for x in list2]
     return rescaled_list1 + rescaled_list2
-
-
-def add_fonts_to_plotly_html_export(filepath: str) -> None:
-    """Adds a style tag with fonts loaded from arcadiascience.com to an HTML file's head section.
-
-    This is necessary for Plotly HTML exports to use the Suisse fonts.
-
-    Args:
-        filepath (str): Path to the HTML file to modify.
-    """
-    with open(filepath) as f:
-        content = f.read()
-
-    soup = BeautifulSoup(content, "html.parser")
-
-    style_tag = soup.new_tag("style")
-    style_tag.string = PLOTLY_HTML_EXPORT_CSS
-
-    if soup.head is None:
-        raise ValueError("Could not find <head> tag in HTML file.")
-    soup.head.append(style_tag)
-
-    with open(filepath, "w") as f:
-        f.write(str(soup))

--- a/arcadia_pycolor/utils.py
+++ b/arcadia_pycolor/utils.py
@@ -1,8 +1,46 @@
+from textwrap import dedent
 from typing import Sequence, Union
 
 import numpy as np
+from bs4 import BeautifulSoup
 
 NumericSequence = Union[Sequence[int], Sequence[float]]
+
+PLOTLY_HTML_EXPORT_CSS = dedent(
+    """
+    @font-face {
+      font-family: "SuisseIntl-Regular";
+      src: url("https://www.arcadiascience.com/fonts/SuisseIntl-Regular.woff2")
+        format("woff2");
+      font-weight: normal;
+      font-style: normal;
+    }
+
+    @font-face {
+      font-family: "SuisseIntl-Medium";
+      src: url("https://www.arcadiascience.com/fonts/SuisseIntl-Medium.woff2")
+        format("woff2");
+      font-weight: normal;
+      font-style: normal;
+    }
+
+    @font-face {
+      font-family: "SuisseIntl-SemiBold";
+      src: url("https://www.arcadiascience.com/fonts/SuisseIntl-SemiBold.woff2")
+        format("woff2");
+      font-weight: normal;
+      font-style: normal;
+    }
+
+    @font-face {
+      font-family: "SuisseIntlMono";
+      src: url("https://www.arcadiascience.com/fonts/SuisseIntlMono.woff2")
+        format("woff2");
+      font-weight: normal;
+      font-style: normal;
+    }
+    """
+)
 
 
 def distribute_values(num_points: int, min_val: float = 0.0, max_val: float = 1.0) -> list[float]:
@@ -73,3 +111,27 @@ def rescale_and_concatenate_values(list1: list[float], list2: list[float]) -> li
     rescaled_list1 = [0.5 * x for x in list1]
     rescaled_list2 = [0.5 * x + 0.5 for x in list2]
     return rescaled_list1 + rescaled_list2
+
+
+def add_fonts_to_plotly_html_export(filepath: str) -> None:
+    """Adds a style tag with fonts loaded from arcadiascience.com to an HTML file's head section.
+
+    This is necessary for Plotly HTML exports to use the Suisse fonts.
+
+    Args:
+        filepath (str): Path to the HTML file to modify.
+    """
+    with open(filepath) as f:
+        content = f.read()
+
+    soup = BeautifulSoup(content, "html.parser")
+
+    style_tag = soup.new_tag("style")
+    style_tag.string = PLOTLY_HTML_EXPORT_CSS
+
+    if soup.head is None:
+        raise ValueError("Could not find <head> tag in HTML file.")
+    soup.head.append(style_tag)
+
+    with open(filepath, "w") as f:
+        f.write(str(soup))

--- a/arcadia_pycolor/utils.py
+++ b/arcadia_pycolor/utils.py
@@ -9,7 +9,7 @@ NumericSequence = Union[Sequence[int], Sequence[float]]
 PLOTLY_HTML_EXPORT_CSS = dedent(
     """
     @font-face {
-      font-family: "SuisseIntl-Regular";
+      font-family: "SuisseIntl";
       src: url("https://www.arcadiascience.com/fonts/SuisseIntl-Regular.woff2")
         format("woff2");
       font-weight: normal;


### PR DESCRIPTION
## Summary

In order for HTML exports of Plotly figures to be embedded on PubPub, the fonts must be loaded from arcadiascience.com. This PR adds the `apc.plotly.export_to_html` method, which appends a `<style>` tag to the head of HTML exports to do just that.

Example usage:

```py
apc.plotly.export_to_html(fig, "scatterplot.html")
```

Unfortunately, remotely loaded fonts are not being applied to axis labels and tick labels in HTML exports of 3D plots. I opened an issue about this bug (or bad usage) in plotly/plotly.js#7413 with more details.

In the meantime, `apc.plotly.export_to_html` will revert all the fonts in a figure to default fonts if it contains any 3D traces. Suisse Int'l Mono will revert to the system monospaced font with a smaller font size.

## Testing

I tested this method by exporting the 2D scatterplot and 3D scatterplot from the corresponding notebooks in `docs/examples` and sending the HTML files to a machine without the Suisse fonts installed.

For the [2D scatter plot (.zip download)](https://github.com/user-attachments/files/20018195/scatterplot.html.zip), I observed that the fonts loaded correctly.
For the [3D scatter plot (.zip download)](https://github.com/user-attachments/files/20018197/3d_plot.html.zip), I observed that the default fonts were applied.

## PR checklist

- [x] Tag the issue(s) or milestones this PR fixes (e.g. `Fixes #123, Resolves #456`).
- [x] Describe the changes you've made.
- [x] Describe any tests you have conducted to confirm that your changes behave as expected.
- [x] If you've added new software dependencies, make sure that those dependencies are included in the appropriate `conda` environments.
- [x] If you've added new functionality, make sure that the documentation is updated accordingly.
- [x] If you encountered bugs or features that you won't address, but should be addressed eventually, create new issues for them.
