### PR TITLE
fix: Add `beautifulsoup4` to package dependencies

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -194,17 +194,18 @@ extras = ["regex"]
 
 [[package]]
 name = "beautifulsoup4"
-version = "4.12.3"
+version = "4.13.4"
 description = "Screen-scraping library"
 optional = false
-python-versions = ">=3.6.0"
+python-versions = ">=3.7.0"
 files = [
-    {file = "beautifulsoup4-4.12.3-py3-none-any.whl", hash = "sha256:b80878c9f40111313e55da8ba20bdba06d8fa3969fc68304167741bbf9e082ed"},
-    {file = "beautifulsoup4-4.12.3.tar.gz", hash = "sha256:74e3d1928edc070d21748185c46e3fb33490f22f52a3addee9aee0f4f7781051"},
+    {file = "beautifulsoup4-4.13.4-py3-none-any.whl", hash = "sha256:9bbbb14bfde9d79f38b8cd5f8c7c85f4b8f2523190ebed90e950a8dea4cb1c4b"},
+    {file = "beautifulsoup4-4.13.4.tar.gz", hash = "sha256:dbb3c4e1ceae6aefebdaf2423247260cd062430a410e38c66f2baa50a8437195"},
 ]
 
 [package.dependencies]
 soupsieve = ">1.2"
+typing-extensions = ">=4.0.0"
 
 [package.extras]
 cchardet = ["cchardet"]
@@ -4374,4 +4375,4 @@ test = ["big-O", "importlib-resources", "jaraco.functools", "jaraco.itertools", 
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<4.0"
-content-hash = "08b7d93c7aea91ab998511aa48e4bcb9828f69f64959652a206d4c61c318d8d7"
+content-hash = "b3a9e3533de6a3a0765595ba760a49baf9d151276f4fe5c06be2be85636bdd81"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ numpy = ">=1.20"
 python = ">=3.9,<4.0"
 plotly = ">=6.0.0"
 kaleido = "==0.2.1"
+beautifulsoup4 = "^4.13.4"
 
 [tool.poetry.group.dev.dependencies]
 ipykernel = ">=6.25.2"


### PR DESCRIPTION
## Summary

Looks like I forgot to add `beautifulsoup4` to the poetry dependencies in #79. This PR fixes that.

## PR checklist

- [x] Tag the issue(s) or milestones this PR fixes (e.g. `Fixes #123, Resolves #456`).
- [x] Describe the changes you've made.
- [x] Describe any tests you have conducted to confirm that your changes behave as expected.
- [x] If you've added new software dependencies, make sure that those dependencies are included in the appropriate `conda` environments.
- [x] If you've added new functionality, make sure that the documentation is updated accordingly.
- [x] If you encountered bugs or features that you won't address, but should be addressed eventually, create new issues for them.
