### PR TITLE
Add message to point users to Google Fonts

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ The package is hosted on PyPI and can be installed using pip:
 pip install arcadia-pycolor
 ```
 
+### Fonts
+
+This package styles figures using [Atkinson Hyperlegible Next](https://fonts.google.com/specimen/Atkinson+Hyperlegible+Next) and [Atkinson Hyperlegible Mono](https://fonts.google.com/specimen/Atkinson+Hyperlegible+Mono). These fonts must be installed on your system for matplotlib figures to render correctly; without them, matplotlib will fall back to its default font. Plotly HTML outputs load the fonts from Google Fonts automatically and do not require local installation.
+
 ## Usage
 
 Please see the quickstart guide for [Matplotlib](docs/mpl_quickstart.md) or [Plotly](docs/plotly_quickstart.md) for an introduction to the package, as well as how to use it to style plots.

--- a/README.md
+++ b/README.md
@@ -10,10 +10,6 @@ The package is hosted on PyPI and can be installed using pip:
 pip install arcadia-pycolor
 ```
 
-### Fonts
-
-This package styles figures using [Atkinson Hyperlegible Next](https://fonts.google.com/specimen/Atkinson+Hyperlegible+Next) and [Atkinson Hyperlegible Mono](https://fonts.google.com/specimen/Atkinson+Hyperlegible+Mono). These fonts must be installed on your system for matplotlib figures to render correctly; without them, matplotlib will fall back to its default font. Plotly HTML outputs load the fonts from Google Fonts automatically and do not require local installation.
-
 ## Usage
 
 Please see the quickstart guide for [Matplotlib](docs/mpl_quickstart.md) or [Plotly](docs/plotly_quickstart.md) for an introduction to the package, as well as how to use it to style plots.

--- a/arcadia_pycolor/mpl.py
+++ b/arcadia_pycolor/mpl.py
@@ -606,8 +606,10 @@ def load_fonts(font_dirpath: Union[str, None] = None) -> None:
 
     if not _is_arcadia_font_set_available():
         print(
-            "Warning: The Arcadia fonts were not found. "
-            "The default matplotlib fonts will be used instead."
+            "Warning: The fonts were not found. "
+            "The default matplotlib fonts will be used instead. "
+            "To install the fonts, visit https://fonts.google.com/specimen/Atkinson+Hyperlegible+Next "
+            "and https://fonts.google.com/specimen/Atkinson+Hyperlegible+Mono"
         )
 
 


### PR DESCRIPTION
Adds links to Google Fonts in the font-not-found error to make it more obvious to users that they'll need to download the fonts
