### PR TITLE
Add Greek character fallback

### DIFF
--- a/arcadia_pycolor/mpl.py
+++ b/arcadia_pycolor/mpl.py
@@ -111,11 +111,11 @@ def _fix_svg_fonts_for_illustrator(filename: str) -> None:
     "font: 500 15px AtkinsonHyperlegibleNext, sans-serif;" or
     "font: 14.5px 'AtkinsonHyperlegibleMono';".
 
-    As a workaround, each CSS font property is explicitly set:
+    As a workaround, each CSS font property is explicitly set and fallback
+    families are stripped so only the Atkinson name remains:
 
     ```html
-    <text style="font-family: AtkinsonHyperlegibleNext, sans-serif;
-                  font-size: 15px; font-weight: 500;">
+    <text style="font-family: AtkinsonHyperlegibleNext; font-size: 15px; font-weight: 500;">
     ```
 
     Additionally, the font family may not be applied correctly in Illustrator

--- a/arcadia_pycolor/mpl.py
+++ b/arcadia_pycolor/mpl.py
@@ -156,6 +156,12 @@ def _fix_svg_fonts_for_illustrator(filename: str) -> None:
     new_content = new_content.replace("Atkinson Hyperlegible Next", "AtkinsonHyperlegibleNext")
     new_content = new_content.replace("Atkinson Hyperlegible Mono", "AtkinsonHyperlegibleMono")
 
+    new_content = re.sub(
+        r"(font-family:\s*'?AtkinsonHyperlegible\w+'?)[^;]*;",
+        r"\1;",
+        new_content,
+    )
+
     with open(filename, "w") as f:
         f.write(new_content)
 

--- a/arcadia_pycolor/style_defaults.py
+++ b/arcadia_pycolor/style_defaults.py
@@ -41,10 +41,25 @@ FONT_FILTER = "Atkinson"
 DEFAULT_FONT = "Atkinson Hyperlegible Next"
 MONOSPACE_FONT = "Atkinson Hyperlegible Mono"
 
-DEFAULT_FONT_PLOTLY = f"AtkinsonHyperlegibleNext, {DEFAULT_FONT}"
-DEFAULT_FONT_PLOTLY_MEDIUM = f"AtkinsonHyperlegibleNext-Medium, {DEFAULT_FONT}"
-DEFAULT_FONT_PLOTLY_SEMIBOLD = f"AtkinsonHyperlegibleNext-SemiBold, {DEFAULT_FONT}"
-MONOSPACE_FONT_PLOTLY = f"AtkinsonHyperlegibleMono, {MONOSPACE_FONT}"
+WEIGHT_MATCHED_FALLBACK_FONT = "Noto Sans"
+FALLBACK_FONT = "DejaVu Sans"
+FALLBACK_MONOSPACE_FONT = "DejaVu Sans Mono"
+
+DEFAULT_FONT_PLOTLY = (
+    f"AtkinsonHyperlegibleNext, {DEFAULT_FONT}, "
+    f"NotoSans, {WEIGHT_MATCHED_FALLBACK_FONT}, {FALLBACK_FONT}, sans-serif"
+)
+DEFAULT_FONT_PLOTLY_MEDIUM = (
+    f"AtkinsonHyperlegibleNext-Medium, {DEFAULT_FONT}, "
+    f"NotoSans-Medium, {WEIGHT_MATCHED_FALLBACK_FONT}, {FALLBACK_FONT}, sans-serif"
+)
+DEFAULT_FONT_PLOTLY_SEMIBOLD = (
+    f"AtkinsonHyperlegibleNext-SemiBold, {DEFAULT_FONT}, "
+    f"NotoSans-SemiBold, {WEIGHT_MATCHED_FALLBACK_FONT}, {FALLBACK_FONT}, sans-serif"
+)
+MONOSPACE_FONT_PLOTLY = (
+    f"AtkinsonHyperlegibleMono, {MONOSPACE_FONT}, {FALLBACK_MONOSPACE_FONT}, monospace"
+)
 
 # Font sizes.
 TITLE_FONT_SIZE = 17  # Key title, legend title
@@ -68,10 +83,9 @@ LINEWEIGHT = 0.75
 # API reference: https://matplotlib.org/stable/api/matplotlib_configuration_api.html.
 ARCADIA_MATPLOTLIB_RC_PARAMS = {
     # Fonts.
-    "font.family": "sans-serif",
+    "font.family": [DEFAULT_FONT, WEIGHT_MATCHED_FALLBACK_FONT, FALLBACK_FONT],
     "font.size": BASE_FONT_SIZE,
-    "font.sans-serif": "Atkinson Hyperlegible Next",
-    "font.monospace": "Atkinson Hyperlegible Mono",
+    "font.monospace": [MONOSPACE_FONT, FALLBACK_MONOSPACE_FONT],
     "font.weight": "regular",
     # Figure.
     "figure.titlesize": TITLE_FONT_SIZE,
@@ -306,6 +320,30 @@ PLOTLY_HTML_EXPORT_CSS = dedent(
     @font-face {
       font-family: "AtkinsonHyperlegibleMono";
       src: url("https://fonts.gstatic.com/s/atkinsonhyperlegiblemono/v8/tssNAoFBci4C4gvhPXrt3wjT1MqSzhA4t7IIcncBiyihrK15gZ4k_SaZHNeiDQ.ttf")
+        format("truetype");
+      font-weight: normal;
+      font-style: normal;
+    }
+
+    @font-face {
+      font-family: "NotoSans";
+      src: url("https://fonts.gstatic.com/s/notosans/v42/o-0mIpQlx3QUlC5A4PNB6Ryti20_6n1iPHjcz6L1SoM-jCpoiyD9A99d.ttf")
+        format("truetype");
+      font-weight: normal;
+      font-style: normal;
+    }
+
+    @font-face {
+      font-family: "NotoSans-Medium";
+      src: url("https://fonts.gstatic.com/s/notosans/v42/o-0mIpQlx3QUlC5A4PNB6Ryti20_6n1iPHjcz6L1SoM-jCpoiyDPA99d.ttf")
+        format("truetype");
+      font-weight: normal;
+      font-style: normal;
+    }
+
+    @font-face {
+      font-family: "NotoSans-SemiBold";
+      src: url("https://fonts.gstatic.com/s/notosans/v42/o-0mIpQlx3QUlC5A4PNB6Ryti20_6n1iPHjcz6L1SoM-jCpoiyAjBN9d.ttf")
         format("truetype");
       font-weight: normal;
       font-style: normal;

--- a/arcadia_pycolor/style_defaults.py
+++ b/arcadia_pycolor/style_defaults.py
@@ -41,21 +41,21 @@ FONT_FILTER = "Atkinson"
 DEFAULT_FONT = "Atkinson Hyperlegible Next"
 MONOSPACE_FONT = "Atkinson Hyperlegible Mono"
 
-WEIGHT_MATCHED_FALLBACK_FONT = "Noto Sans"
+PREFERRED_FALLBACK_FONT = "Noto Sans"
 FALLBACK_FONT = "DejaVu Sans"
 FALLBACK_MONOSPACE_FONT = "DejaVu Sans Mono"
 
 DEFAULT_FONT_PLOTLY = (
     f"AtkinsonHyperlegibleNext, {DEFAULT_FONT}, "
-    f"NotoSans, {WEIGHT_MATCHED_FALLBACK_FONT}, {FALLBACK_FONT}, sans-serif"
+    f"NotoSans, {PREFERRED_FALLBACK_FONT}, {FALLBACK_FONT}, sans-serif"
 )
 DEFAULT_FONT_PLOTLY_MEDIUM = (
     f"AtkinsonHyperlegibleNext-Medium, {DEFAULT_FONT}, "
-    f"NotoSans-Medium, {WEIGHT_MATCHED_FALLBACK_FONT}, {FALLBACK_FONT}, sans-serif"
+    f"NotoSans-Medium, {PREFERRED_FALLBACK_FONT}, {FALLBACK_FONT}, sans-serif"
 )
 DEFAULT_FONT_PLOTLY_SEMIBOLD = (
     f"AtkinsonHyperlegibleNext-SemiBold, {DEFAULT_FONT}, "
-    f"NotoSans-SemiBold, {WEIGHT_MATCHED_FALLBACK_FONT}, {FALLBACK_FONT}, sans-serif"
+    f"NotoSans-SemiBold, {PREFERRED_FALLBACK_FONT}, {FALLBACK_FONT}, sans-serif"
 )
 MONOSPACE_FONT_PLOTLY = (
     f"AtkinsonHyperlegibleMono, {MONOSPACE_FONT}, {FALLBACK_MONOSPACE_FONT}, monospace"
@@ -82,8 +82,9 @@ LINEWEIGHT = 0.75
 # Matplotlib runtime configuration parameters.
 # API reference: https://matplotlib.org/stable/api/matplotlib_configuration_api.html.
 ARCADIA_MATPLOTLIB_RC_PARAMS = {
-    # Fonts.
-    "font.family": [DEFAULT_FONT, WEIGHT_MATCHED_FALLBACK_FONT, FALLBACK_FONT],
+    # Fonts. font.family must be a list of specific names — generic families like
+    # "sans-serif" collapse to one font and skip per-glyph fallback entirely.
+    "font.family": [DEFAULT_FONT, PREFERRED_FALLBACK_FONT, FALLBACK_FONT],
     "font.size": BASE_FONT_SIZE,
     "font.monospace": [MONOSPACE_FONT, FALLBACK_MONOSPACE_FONT],
     "font.weight": "regular",


### PR DESCRIPTION
## PR checklist

- [ ] Atkinson Hyperlegible Next does not include certain Greek characters that may appear in axis labels (e.g., beta). This PR adds a per-glyph fallback for characters that do not appear in Atkinson Hyperlegible Next. It first falls back to Noto since this font has a close weight match to Atkinson Hyperlegible, and then the default matplotlib font (DejaVu Sans).
- [ ] Ran bundled test suite and reviewed figure outputs. Also created figures with the relevant Greek characters to confirm they appear in Plotly HTMLs, SVGs, PDFs, and PNGs.
