### PR TITLE
Harden save_figure error handling in mpl and plotly utils

### DIFF
--- a/arcadia_pycolor/mpl.py
+++ b/arcadia_pycolor/mpl.py
@@ -37,6 +37,8 @@ from arcadia_pycolor.style_defaults import (
     FigureSize,
 )
 
+logger = logging.getLogger(__name__)
+
 # Disable matplotlib's very noisy warnings when the Arcadia fonts are not installed.
 logging.getLogger("matplotlib.font_manager").setLevel(logging.ERROR)
 
@@ -170,8 +172,8 @@ def save_figure(
     filepath: str,
     size: FigureSize,
     filetypes: Union[list[str], None] = None,
-    context: str = "web",
-    **savefig_kwargs: dict[Any, Any],
+    context: Literal["web", "print"] = "web",
+    **savefig_kwargs: Any,
 ) -> None:
     """Saves the current figure to a file using Arcadia's margin, padding, and dpi settings.
 
@@ -183,10 +185,26 @@ def save_figure(
             - "half_square"
         filetypes (list[str], optional): The file types(s) to save the figure to.
             If None, the original filetype of `filepath` is used.
-            If the original filetype is not in `filetypes`, it is appended to the list.
+            If the original filetype is not in `filetypes`, it is added to the list.
+            Valid filetypes are: 'eps', 'jpg', 'jpeg', 'pdf', 'pgf', 'png', 'ps',
+            'raw', 'rgba', 'svg', 'svgz', 'tif', 'tiff', 'webp'. Invalid filetypes
+            are skipped with a warning.
         context (str): The context to save the figure in, either 'web' or 'print'.
         **savefig_kwargs: Additional keyword arguments to pass to `plt.savefig`.
+
+    Note:
+        Padding is applied via an explicit `bbox_inches` Bbox. The default `pad_inches`
+        setting only takes effect if a caller overrides `bbox_inches="tight"` through
+        `savefig_kwargs`.
+
+    Raises:
+        ValueError: If `size` is not a valid figure size, if no filetype can be
+            determined, or if no valid filetype remains to write.
     """
+    if size not in FIGURE_SIZES_IN_INCHES:
+        valid_sizes = ", ".join(repr(key) for key in FIGURE_SIZES_IN_INCHES)
+        raise ValueError(f"Invalid size {size!r}. Must be one of: {valid_sizes}.")
+
     width, height = FIGURE_SIZES_IN_INCHES[size]
     bbox_inches = Bbox.from_bounds(
         -FIGURE_PADDING_INCHES,
@@ -195,8 +213,8 @@ def save_figure(
         height,
     )
 
-    kwargs = SAVEFIG_KWARGS_WEB if context == "web" else SAVEFIG_KWARGS_PRINT
-    kwargs.update(**savefig_kwargs, bbox_inches=bbox_inches)  # type: ignore
+    base_kwargs = SAVEFIG_KWARGS_WEB if context == "web" else SAVEFIG_KWARGS_PRINT
+    kwargs = {**base_kwargs, **savefig_kwargs, "bbox_inches": bbox_inches}
 
     # Gets a list of valid filetypes for saving figures from matplotlib.
     valid_filetypes = list(FigureCanvasBase.get_supported_filetypes().keys())
@@ -209,14 +227,24 @@ def save_figure(
         if not filetype:
             raise ValueError("The filename must include a filetype if no filetypes are provided.")
         filetypes = [filetype]
-    else:
-        filetypes.append(filetype)
+    elif filetype and filetype not in filetypes:
+        filetypes = [*filetypes, filetype]
 
-    for ftype in filetypes:
-        if ftype not in valid_filetypes:
-            print(f"Invalid filetype '{ftype}'. Skipping.")
-            continue
+    invalid_filetypes = [ftype for ftype in filetypes if ftype not in valid_filetypes]
+    if invalid_filetypes:
+        logger.warning(
+            "Skipping invalid filetype(s): %s. Valid filetypes are: %s.",
+            ", ".join(repr(f) for f in invalid_filetypes),
+            ", ".join(valid_filetypes),
+        )
 
+    filetypes_to_write = [ftype for ftype in filetypes if ftype in valid_filetypes]
+    if not filetypes_to_write:
+        raise ValueError(
+            f"No valid filetypes to write. Valid filetypes are: {', '.join(valid_filetypes)}."
+        )
+
+    for ftype in filetypes_to_write:
         plt.savefig(fname=f"{filename}.{ftype}", **kwargs)
 
         if ftype == "svg":

--- a/arcadia_pycolor/plotly_utils.py
+++ b/arcadia_pycolor/plotly_utils.py
@@ -1,3 +1,4 @@
+import logging
 from pathlib import Path
 from typing import Any, Literal, Union, get_args
 
@@ -8,6 +9,7 @@ from bs4 import BeautifulSoup
 from arcadia_pycolor.style_defaults import (
     ARCADIA_PLOTLY_TEMPLATE_LAYOUT,
     DEFAULT_FONT_PLOTLY,
+    FIGURE_PADDING_PIXELS,
     FIGURE_SIZES_IN_PIXELS,
     MONOSPACE_FONT_PLOTLY,
     MONOSPACE_FONT_SIZE,
@@ -27,6 +29,8 @@ PLOTLY_3D_TRACE_TYPES = (
     go.Parcoords,
     go.Streamtube,
 )
+
+logger = logging.getLogger(__name__)
 
 AxisSelector = Literal["x", "y", "z", "xy", "yz", "xz", "xyz", "all"]
 
@@ -142,7 +146,7 @@ def save_figure(
     filepath: str,
     size: FigureSize,
     filetypes: Union[list[str], None] = None,
-    **write_image_kwargs: dict[Any, Any],
+    **write_image_kwargs: Any,
 ) -> None:
     """Saves the current figure to a file without any margins or padding.
 
@@ -161,8 +165,14 @@ def save_figure(
             - "half_square"
         filetypes (list[str], optional): The file types(s) to save the figure to.
             If None, the original filetype of `filepath` is used.
-            If the original filetype is not in `filetypes`, it is appended to the list.
+            If the original filetype is not in `filetypes`, it is added to the list.
+            Valid filetypes are: 'png', 'jpg', 'jpeg', 'webp', 'svg', 'pdf'. Invalid
+            filetypes are skipped with a warning.
         **write_image_kwargs: Additional keyword arguments to pass to `fig.write_image`.
+
+    Raises:
+        ValueError: If `size` is not a valid figure size, if no filetype can be
+            determined, or if no valid filetype remains to write.
     """
     # By default, our Plotly template attempts to add 40 pixels of margin on all sides.
     # However, due to Plotly's internal automargin strategy, the margin is not always
@@ -171,9 +181,13 @@ def save_figure(
     # For exports, we want to remove the margins and update the figure dimensions
     # so that the correct margins can be applied in Adobe Illustrator.
     # TODO(#69): Write a custom function to apply the margins.
+    if size not in FIGURE_SIZES_IN_PIXELS:
+        valid_sizes = ", ".join(repr(key) for key in FIGURE_SIZES_IN_PIXELS)
+        raise ValueError(f"Invalid size {size!r}. Must be one of: {valid_sizes}.")
+
     updated_margins = dict(l=0, r=0, t=0, b=0)
-    updated_width = FIGURE_SIZES_IN_PIXELS[size][0] - 60
-    updated_height = FIGURE_SIZES_IN_PIXELS[size][1] - 60
+    updated_width = FIGURE_SIZES_IN_PIXELS[size][0] - 2 * FIGURE_PADDING_PIXELS
+    updated_height = FIGURE_SIZES_IN_PIXELS[size][1] - 2 * FIGURE_PADDING_PIXELS
 
     # For some reason, the axis linewidths (which are set to 1 px) are being rendered as
     # 1 pt in Illustrator. Manually setting these to 0.75 px renders them as 0.75 pt.
@@ -184,9 +198,11 @@ def save_figure(
         margin=updated_margins,
         width=updated_width,
         height=updated_height,
-        xaxis=dict(linewidth=updated_axis_linewidth),
-        yaxis=dict(linewidth=updated_axis_linewidth),
     )
+    # Apply to every axis (including subplot axes such as xaxis2, yaxis2, ...), since
+    # update_layout(xaxis=..., yaxis=...) would only affect the primary axis pair.
+    fig_export.update_xaxes(linewidth=updated_axis_linewidth)
+    fig_export.update_yaxes(linewidth=updated_axis_linewidth)
 
     # If no file types are provided, use the filetype from the file path.
     valid_filetypes = ["png", "jpg", "jpeg", "webp", "svg", "pdf"]
@@ -198,13 +214,24 @@ def save_figure(
         if not filetype:
             raise ValueError("The filename must include a filetype if no filetypes are provided.")
         filetypes = [filetype]
-    else:
-        filetypes.append(filetype)
+    elif filetype and filetype not in filetypes:
+        filetypes = [*filetypes, filetype]
 
-    for ftype in filetypes:
-        if ftype not in valid_filetypes:
-            print(f"Invalid filetype '{ftype}'. Skipping.")
-            continue
+    invalid_filetypes = [ftype for ftype in filetypes if ftype not in valid_filetypes]
+    if invalid_filetypes:
+        logger.warning(
+            "Skipping invalid filetype(s): %s. Valid filetypes are: %s.",
+            ", ".join(repr(f) for f in invalid_filetypes),
+            ", ".join(valid_filetypes),
+        )
+
+    filetypes_to_write = [ftype for ftype in filetypes if ftype in valid_filetypes]
+    if not filetypes_to_write:
+        raise ValueError(
+            f"No valid filetypes to write. Valid filetypes are: {', '.join(valid_filetypes)}."
+        )
+
+    for ftype in filetypes_to_write:
         try:
             fig_export.write_image(f"{filename}.{ftype}", **write_image_kwargs)
         except Exception as error:

--- a/arcadia_pycolor/tests/test_mpl_save_figure.py
+++ b/arcadia_pycolor/tests/test_mpl_save_figure.py
@@ -1,3 +1,5 @@
+import logging
+
 import matplotlib.pyplot as plt
 import pytest
 
@@ -39,25 +41,47 @@ def test_mpl_save_figure_filetype_examples(tmp_path, fname, filetypes, expected_
 
 
 @pytest.mark.parametrize(
+    "fname, filetypes, expected_outputs",
+    [
+        # An invalid filetype is skipped (with a warning) while valid ones are still written.
+        ("test.pdf", ["invalid"], ["test.pdf"]),
+        ("test.invalid", ["pdf"], ["test.pdf"]),
+    ],
+)
+def test_mpl_save_figure_filetype_invalid_skipped(
+    tmp_path, fname, filetypes, expected_outputs, caplog
+):
+    simple_plot()
+
+    with caplog.at_level(logging.WARNING, logger="arcadia_pycolor.mpl"):
+        apc.mpl.save_figure(
+            tmp_path / fname,
+            size="half_square",
+            filetypes=filetypes,
+        )
+
+    assert "invalid" in caplog.text.lower()
+    for output in expected_outputs:
+        assert (tmp_path / output).is_file()
+
+
+@pytest.mark.parametrize(
     "fname, filetypes",
     [
-        ("test.pdf", ["invalid"]),
         ("test", ["invalid"]),
-        ("test.invalid", ["pdf"]),
         ("test.invalid", None),
     ],
 )
-def test_mpl_save_figure_filetype_invalid(tmp_path, fname, filetypes, capsys):
+def test_mpl_save_figure_filetype_all_invalid_raises(tmp_path, fname, filetypes):
+    """When no valid filetypes remain, the function raises instead of silently doing nothing."""
     simple_plot()
 
-    apc.mpl.save_figure(
-        tmp_path / fname,
-        size="half_square",
-        filetypes=filetypes,
-    )
-
-    captured = capsys.readouterr()
-    assert "Invalid filetype 'invalid'. Skipping." in captured.out
+    with pytest.raises(ValueError):
+        apc.mpl.save_figure(
+            tmp_path / fname,
+            size="half_square",
+            filetypes=filetypes,
+        )
 
 
 def test_mpl_save_figure_no_filetype(tmp_path):

--- a/arcadia_pycolor/tests/test_plotly_save_figure.py
+++ b/arcadia_pycolor/tests/test_plotly_save_figure.py
@@ -1,3 +1,5 @@
+import logging
+
 import plotly.express as px
 import pytest
 
@@ -45,24 +47,46 @@ def test_plotly_save_figure_filetype_examples(tmp_path, fname, filetypes, expect
 
 
 @pytest.mark.parametrize(
+    "fname, filetypes, expected_outputs",
+    [
+        # An invalid filetype is skipped (with a warning) while valid ones are still written.
+        ("test.pdf", ["invalid"], ["test.pdf"]),
+        ("test.invalid", ["pdf"], ["test.pdf"]),
+    ],
+)
+def test_plotly_save_figure_filetype_invalid_skipped(
+    tmp_path, fname, filetypes, expected_outputs, caplog
+):
+    fig = simple_plot()
+    with caplog.at_level(logging.WARNING, logger="arcadia_pycolor.plotly_utils"):
+        apc.plotly.save_figure(
+            fig,
+            tmp_path / fname,
+            "float",
+            filetypes=filetypes,
+        )
+    assert "invalid" in caplog.text.lower()
+    for output in expected_outputs:
+        assert (tmp_path / output).is_file()
+
+
+@pytest.mark.parametrize(
     "fname, filetypes",
     [
-        ("test.pdf", ["invalid"]),
         ("test", ["invalid"]),
-        ("test.invalid", ["pdf"]),
         ("test.invalid", None),
     ],
 )
-def test_plotly_save_figure_filetype_invalid(tmp_path, fname, filetypes, capsys):
+def test_plotly_save_figure_filetype_all_invalid_raises(tmp_path, fname, filetypes):
+    """When no valid filetypes remain, the function raises instead of silently doing nothing."""
     fig = simple_plot()
-    apc.plotly.save_figure(
-        fig,
-        tmp_path / fname,
-        "float",
-        filetypes=filetypes,
-    )
-    captured = capsys.readouterr()
-    assert "Invalid filetype 'invalid'. Skipping." in captured.out
+    with pytest.raises(ValueError):
+        apc.plotly.save_figure(
+            fig,
+            tmp_path / fname,
+            "float",
+            filetypes=filetypes,
+        )
 
 
 def test_plotly_save_figure_no_filetype(tmp_path):


### PR DESCRIPTION
## Summary

Hardens both `save_figure` functions (`arcadia_pycolor/mpl.py` and `arcadia_pycolor/plotly_utils.py`) with better validation, logging, and a couple of bug fixes.

- **Fix shared-state mutation (`mpl`)**: the old code did `kwargs = SAVEFIG_KWARGS_WEB; kwargs.update(...)`, which mutated the module-level defaults in place on every call. Now builds a fresh dict.
- **Fix multi-axis linewidth (`plotly`)**: switched from `update_layout(xaxis=..., yaxis=...)` to `update_xaxes`/`update_yaxes` so subplot axes (`xaxis2`, etc.) also get the corrected linewidth.
- **Derive padding from a constant (`plotly`)**: replaced the hardcoded `- 60` with `- 2 * FIGURE_PADDING_PIXELS`.
- **Validation & semantics (both)**: validate `size` up front with a clear `ValueError`; replace `print()` with `logger.warning()` for invalid filetypes; dedupe the path-derived filetype without mutating the caller's list; raise when no valid filetype remains instead of silently writing nothing.
- **Type hints & docs (both)**: `context: Literal["web", "print"]`, `**kwargs: Any` (was incorrectly `dict[Any, Any]`), and document valid filetypes in the docstrings.

## Test plan

- [x] `pytest arcadia_pycolor/tests/test_mpl_save_figure.py arcadia_pycolor/tests/test_plotly_save_figure.py`
- Tests were split into "some invalid filetypes → skipped with a warning (valid ones still written)" and "all invalid → raises `ValueError`".

Made with [Cursor](https://cursor.com)