### PR TITLE
Fix diverging gradients crashing matplotlib colormap registration

### DIFF
--- a/arcadia_pycolor/gradient.py
+++ b/arcadia_pycolor/gradient.py
@@ -253,7 +253,8 @@ class Gradient:
                 v = adjusted_values[-1] + epsilon
             adjusted_values.append(v)
         colors = [
-            (v, anchor.color.hex_code) for v, anchor in zip(adjusted_values, self.anchors, strict=True)
+            (v, anchor.color.hex_code) for v, anchor in zip(adjusted_values, self.anchors,
+                                                            strict=True)
         ]
         return mcolors.LinearSegmentedColormap.from_list(
             self.name,

--- a/arcadia_pycolor/gradient.py
+++ b/arcadia_pycolor/gradient.py
@@ -253,7 +253,7 @@ class Gradient:
                 v = adjusted_values[-1] + epsilon
             adjusted_values.append(v)
         colors = [
-            (v, anchor.color.hex_code) for v, anchor in zip(adjusted_values, self.anchors)
+            (v, anchor.color.hex_code) for v, anchor in zip(adjusted_values, self.anchors, strict=True)
         ]
         return mcolors.LinearSegmentedColormap.from_list(
             self.name,

--- a/arcadia_pycolor/gradient.py
+++ b/arcadia_pycolor/gradient.py
@@ -257,7 +257,7 @@ class Gradient:
             (v, anchor.color.hex_code)
             for v, anchor in zip(adjusted_values, self.anchors, strict=True)
         ]
-        
+
         return mcolors.LinearSegmentedColormap.from_list(
             self.name,
             colors=colors,

--- a/arcadia_pycolor/gradient.py
+++ b/arcadia_pycolor/gradient.py
@@ -237,8 +237,24 @@ class Gradient:
         )
 
     def to_mpl_cmap(self) -> mcolors.LinearSegmentedColormap:
-        """Converts the gradient to a matplotlib colormap."""
-        colors = [(anchor.value, anchor.color.hex_code) for anchor in self.anchors]
+        """Converts the gradient to a matplotlib colormap.
+
+        Diverging gradients (built by concatenating two gradients with ``+``) store
+        the shared midpoint color at position 0.5 in *both* halves, resulting in a
+        duplicate anchor value.  ``LinearSegmentedColormap.from_list`` requires
+        strictly increasing positions, so any duplicate is nudged forward by a
+        negligible epsilon before the colormap is constructed.
+        """
+        epsilon = 1e-10
+        adjusted_values: list[float] = []
+        for anchor in self.anchors:
+            v = anchor.value
+            if adjusted_values and v <= adjusted_values[-1]:
+                v = adjusted_values[-1] + epsilon
+            adjusted_values.append(v)
+        colors = [
+            (v, anchor.color.hex_code) for v, anchor in zip(adjusted_values, self.anchors)
+        ]
         return mcolors.LinearSegmentedColormap.from_list(
             self.name,
             colors=colors,

--- a/arcadia_pycolor/gradient.py
+++ b/arcadia_pycolor/gradient.py
@@ -252,10 +252,12 @@ class Gradient:
             if adjusted_values and v <= adjusted_values[-1]:
                 v = adjusted_values[-1] + epsilon
             adjusted_values.append(v)
+
         colors = [
-            (v, anchor.color.hex_code) for v, anchor in zip(adjusted_values, self.anchors,
-                                                            strict=True)
+            (v, anchor.color.hex_code)
+            for v, anchor in zip(adjusted_values, self.anchors, strict=True)
         ]
+        
         return mcolors.LinearSegmentedColormap.from_list(
             self.name,
             colors=colors,

--- a/arcadia_pycolor/tests/test_gradients.py
+++ b/arcadia_pycolor/tests/test_gradients.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pytest
 
+import arcadia_pycolor as apc
 from arcadia_pycolor import Gradient, HexCode
 from arcadia_pycolor.colors import black, white
 
@@ -196,3 +197,28 @@ def test_gradient_anchor_properties():
     # Check parent properties.
     assert gradient.anchor_colors == colors
     assert gradient.anchor_values == values
+
+
+def test_diverging_gradient_to_mpl_cmap_no_duplicate_anchor():
+    """Regression: diverging gradients must not crash LinearSegmentedColormap.from_list.
+
+    The ``+`` operator shares the midpoint color in both halves, which produced a
+    duplicate position value (0.5 twice) before the epsilon fix in to_mpl_cmap().
+    """
+    left = Gradient("left", [HexCode("red", "#FF0000"), HexCode("white", "#FFFFFF")])
+    right = Gradient("right", [HexCode("white", "#FFFFFF"), HexCode("blue", "#0000FF")])
+    diverging = left + right
+    # Must not raise ValueError from matplotlib.
+    cmap = diverging.to_mpl_cmap()
+    assert cmap is not None
+
+
+@pytest.mark.parametrize(
+    "gradient",
+    [apc.gradients.orange_sage, apc.gradients.red_blue, apc.gradients.purple_green],
+    ids=["orange_sage", "red_blue", "purple_green"],
+)
+def test_builtin_diverging_gradients_to_mpl_cmap(gradient):
+    """Regression: all built-in diverging gradients must convert to a matplotlib colormap."""
+    cmap = gradient.to_mpl_cmap()
+    assert cmap is not None


### PR DESCRIPTION
## PR checklist

- [ ] Tag the issue(s) or milestones this PR fixes (e.g. `Fixes #123, Resolves #456`).
- [x] Describe the changes you've made.
- [x] Describe any tests you have conducted to confirm that your changes behave as expected.
- [ ] If you've added new software dependencies, make sure that those dependencies are included in the appropriate `conda` environments.
- [ ] If you've added new functionality, make sure that the documentation is updated accordingly.
- [ ] If you encountered bugs or features that you won't address, but should be addressed eventually, create new issues for them.

## Description

`rescale_and_concatenate_values` rescales the left half of a diverging gradient to `[0, 0.5]` and the right half to `[0.5, 1]`. This means the last anchor of the left half and the first anchor of the right half both land at exactly `0.5`, producing a duplicate position value.

`matplotlib.colors.LinearSegmentedColormap.from_list` requires **strictly increasing** position values and raises a `ValueError` on any duplicate:

```
ValueError: the values passed in the (value, color) pairs must increase monotonically from 0 to 1.
```

This affects all three diverging gradients (`orange_sage`, `red_blue`, `purple_green`) and — as of v0.8.0 where `to_plotly_colorscale()` is called at module level in `style_defaults.py` — causes `import arcadia_pycolor` to fail entirely.

## Fix

In `Gradient.to_mpl_cmap`, nudge any duplicate anchor value forward by `epsilon = 1e-10` before passing the `(position, color)` pairs to `from_list`. The adjustment is visually imperceptible but satisfies matplotlib's strict-monotonicity requirement.

## Testing

Confirmed that `import arcadia_pycolor as apc` and `apc.mpl.setup()` both succeed after the fix, and that the diverging colormaps render correctly.