### PR TITLE
Centralize colorspacious warning suppression

### DIFF
--- a/arcadia_pycolor/_colorspacious.py
+++ b/arcadia_pycolor/_colorspacious.py
@@ -1,0 +1,10 @@
+import warnings
+
+with warnings.catch_warnings():
+    # colorspacious uses invalid escape sequences in docstrings (e.g. `\Delta`).
+    # On Python 3.12+ these emit SyntaxWarning at compile time; on 3.10-3.11 they
+    # emit DeprecationWarning. A module filter does not match compile-time warnings.
+    warnings.filterwarnings("ignore", message="invalid escape sequence")
+    from colorspacious import cspace_convert, cspace_converter  # type: ignore
+
+__all__ = ["cspace_convert", "cspace_converter"]

--- a/arcadia_pycolor/cvd.py
+++ b/arcadia_pycolor/cvd.py
@@ -1,14 +1,10 @@
-import warnings
 from typing import Any, cast, overload
 
 import matplotlib as mpl
 import numpy as np
-
-with warnings.catch_warnings():
-    warnings.filterwarnings("ignore", category=SyntaxWarning, module="colorspacious")
-    from colorspacious import cspace_convert  # type: ignore
 from numpy.typing import NDArray
 
+from arcadia_pycolor._colorspacious import cspace_convert
 from arcadia_pycolor.gradient import Gradient
 from arcadia_pycolor.hexcode import HexCode
 from arcadia_pycolor.palette import Palette

--- a/arcadia_pycolor/hexcode.py
+++ b/arcadia_pycolor/hexcode.py
@@ -1,14 +1,10 @@
 from __future__ import annotations
 import re
-import warnings
 from typing import Any, cast
 
 import matplotlib.colors as mcolors
 
-with warnings.catch_warnings():
-    warnings.filterwarnings("ignore", category=SyntaxWarning, module="colorspacious")
-    from colorspacious import cspace_converter  # type: ignore
-
+from arcadia_pycolor._colorspacious import cspace_converter
 from arcadia_pycolor.display import colorize
 
 

--- a/arcadia_pycolor/plot.py
+++ b/arcadia_pycolor/plot.py
@@ -1,16 +1,12 @@
-import warnings
 from typing import cast
 
 import matplotlib as mpl
 import matplotlib.pyplot as plt
 import numpy as np
-
-with warnings.catch_warnings():
-    warnings.filterwarnings("ignore", category=SyntaxWarning, module="colorspacious")
-    from colorspacious import cspace_converter  # type: ignore
 from matplotlib.figure import Figure
 from numpy.typing import NDArray
 
+from arcadia_pycolor._colorspacious import cspace_converter
 from arcadia_pycolor.gradient import Gradient
 from arcadia_pycolor.gradients import all_gradients
 from arcadia_pycolor.palettes import all_palettes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,4 +111,7 @@ reportUnknownMemberType = false
 filterwarnings = [
     # Ignore deprecation warnings for Plotly.
     'ignore:.* is deprecated!:DeprecationWarning',
+    # colorspacious uses invalid escape sequences in docstrings (e.g. `\Delta`).
+    'ignore:invalid escape sequence:SyntaxWarning',
+    'ignore:invalid escape sequence:DeprecationWarning',
 ]


### PR DESCRIPTION
## Summary
- Add `_colorspacious.py` shim to import `colorspacious` with a message-based warning filter that catches invalid escape sequence warnings at compile time
- Replace duplicated warning boilerplate in `cvd.py`, `hexcode.py`, and `plot.py` with imports from the shim
- Add pytest `filterwarnings` entries for both `SyntaxWarning` and `DeprecationWarning` across Python versions

## Test plan
- [x] `uv run pytest` — 219 tests passed
- [x] `uv run python -W default -c "import arcadia_pycolor.cvd; import arcadia_pycolor.hexcode; import arcadia_pycolor.plot"` — no warnings emitted


Made with [Cursor](https://cursor.com)