### PR TITLE
Wire runtime __version__ to hatch-vcs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,7 +77,7 @@ venv/
 # OS
 .DS_Store
 
-# written by setuptools_scm
+# written by hatch-vcs
 **/_version.py
 
 # Nextflow related folders and files

--- a/arcadia_pycolor/__init__.py
+++ b/arcadia_pycolor/__init__.py
@@ -6,8 +6,10 @@ from .gradient import Gradient
 from .hexcode import HexCode
 from .palette import Palette
 
-# This is a placeholder that will be replaced by the version number at build time.
-__version__ = "0.0.0"
+try:
+    from ._version import __version__
+except ImportError:
+    __version__ = "0.0.0"
 
 __all__ = [
     "cvd",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,9 @@ dev = [
 [tool.hatch.version]
 source = "vcs"
 
+[tool.hatch.build.hooks.vcs]
+version-file = "arcadia_pycolor/_version.py"
+
 [tool.hatch.build.targets.wheel]
 packages = ["arcadia_pycolor"]
 


### PR DESCRIPTION
Fixes an issue with `__version__`. Old behavior on a fresh installation:

```python
>>> import arcadia_pycolor as apc
>>> apc.__version__
'0.0.0'
```

## Summary
- Generate `arcadia_pycolor/_version.py` at build time via hatch-vcs so runtime `__version__` matches git tags
- Import the generated version in `__init__.py`, with a fallback to `"0.0.0"` when the file is missing
- Update `.gitignore` comment to reference hatch-vcs instead of setuptools_scm

## Test plan
- [x] `uv run python -c "import arcadia_pycolor; print(arcadia_pycolor.__version__)"` returns a git-derived version (not `0.0.0`)
- [x] `uv build` produces a wheel containing `arcadia_pycolor/_version.py` with the expected version string


Made with [Cursor](https://cursor.com)